### PR TITLE
Add automatically reload function

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -3,7 +3,7 @@ $(function () {
   function buildHTML(message) {
     if (message.image) {
       var html =
-        `<div class="message">
+        `<div class="message" data-message-id=${message.id}>
           <div class="message-info">
             <div class="message-info__talker">
               ${ message.user_name}
@@ -21,7 +21,7 @@ $(function () {
         </div>`
     } else {
       var html =
-        `<div class="message">
+        `<div class="message" data-message-id=${message.id}>
           <div class="message-info">
             <div class="message-info__talker">
               ${ message.user_name}
@@ -63,4 +63,30 @@ $(function () {
         alert("メッセージ送信に失敗しました");
       })
   })
-})
+
+  var reloadMessages = function () {
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: { id: last_message_id }
+    })
+      .done(function (messages) {
+        if (messages.length !== 0) {
+          var insertHTML = '';
+          $.each(messages, function (i, message) {
+            insertHTML += buildHTML(message)
+          });
+          $('.messages').append(insertHTML);
+          $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight });
+        }
+      })
+      .fail(function () {
+        alert('error');
+      });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function () {
 
   function buildHTML(message) {
     if (message.image) {
-      let html =
+      var html =
         `<div class="message">
           <div class="message-info">
             <div class="message-info__talker">
@@ -20,7 +20,7 @@ $(function () {
           </div>
         </div>`
     } else {
-      let html =
+      var html =
         `<div class="message">
           <div class="message-info">
             <div class="message-info__talker">
@@ -42,8 +42,8 @@ $(function () {
 
   $('#new_message').on('submit', function (e) {
     e.preventDefault()
-    let formData = new FormData(this);
-    let url = $(this).attr('action')
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
     $.ajax({
       url: url,
       type: "POST",
@@ -53,7 +53,7 @@ $(function () {
       contentType: false
     })
       .done(function (data) {
-        let html = buildHTML(data);
+        var html = buildHTML(data);
         $('.messages').append(html);
         $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight });
         $('form')[0].reset();

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content     message.content
+  json.image       message.image.url
+  json.created_at  message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name   message.user.name
+  json.id          message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message-info
     .message-info__talker
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name   @message.user.name
 json.created_at  @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.content     @message.content
 json.image       @message.image_url
+json.id          @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { fomat: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#What
chatspaceの投稿メッセージ一覧表示に自動更新を実装した。新たに投稿されたメッセージを非同期通信で自動に更新可能とした。自動更新されるのはグループメッセージの一覧表示のみ。

#Why
他のユーザーが投稿した内容をリロードすることなく閲覧できるようにするため。

https://gyazo.com/2a5d4e25f667dc9741198b567e4ecb35
https://gyazo.com/a95f522f89ce78f0c7dc370d194e57eb